### PR TITLE
Fix on web security config and deployment yaml

### DIFF
--- a/{{ project_slug }}/kubernetes/streams-{{ project_slug }}/k8s/streams-dev/01-deployment.yaml
+++ b/{{ project_slug }}/kubernetes/streams-{{ project_slug }}/k8s/streams-dev/01-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         team: streams
         department: technology
         environment: streams-dev
+        service: {{ project_slug }}
     spec:
       topologySpreadConstraints:
         - maxSkew: 1

--- a/{{ project_slug }}/src/main/java/{{ package_dirs }}/{{ root_package }}/config/WebSecurityConfig.java
+++ b/{{ project_slug }}/src/main/java/{{ package_dirs }}/{{ root_package }}/config/WebSecurityConfig.java
@@ -4,13 +4,15 @@ import static org.springframework.security.config.http.SessionCreationPolicy.STA
 
 import {{ base_package }}.{{ root_package }}.config.filter.TokenAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
-@EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
+@Configuration
+@EnableMethodSecurity(securedEnabled = true)
 public class WebSecurityConfig {
 
   private final TokenAuthenticationFilter tokenAuthenticationFilter;


### PR DESCRIPTION
1. Replaced web security annotation [@EnableGlobalMethodSecurity](https://docs.spring.io/spring-security/site/docs/6.2.0/api/org/springframework/security/config/annotation/method/configuration/EnableGlobalMethodSecurity.html) with [@EnableMethodSecurity](https://docs.spring.io/spring-security/site/docs/6.2.0/api/org/springframework/security/config/annotation/method/configuration/EnableMethodSecurity.html) (Reference: [here](https://docs.spring.io/spring-security/reference/servlet/authorization/method-security.html#migration-enableglobalmethodsecurity))
2. Add `service` meta data in the deployment yaml