### PR TITLE
ci: Upgrade cache action to V4

### DIFF
--- a/{{ project_slug }}/.github/workflows/main-test-release.yaml
+++ b/{{ project_slug }}/.github/workflows/main-test-release.yaml
@@ -102,7 +102,7 @@ jobs:
           echo "ecr_registry={{ "${{ steps.login-ecr.outputs.registry }}" }}/imgarena/streams/{{ project_slug }}" >> $GITHUB_ENV
 
       - name: Restore Docker registry cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/docker-registry
           key: {{ "${{ runner.os }}" }}-docker-registry-{{ "${{ github.workflow }}" }}-{{ "${{ hashFiles('**/pom.xml') }}" }}


### PR DESCRIPTION
Github has deprecated action V2 causing out builds to fail

closes: STRMS-2845